### PR TITLE
createRoom API 구현

### DIFF
--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -15,6 +15,7 @@ exports.signIn = async (req, res, next) => {
       nickname,
       imageUrl,
       gameHistory: [],
+      refreshToken: null,
     });
   }
 
@@ -29,5 +30,10 @@ exports.signIn = async (req, res, next) => {
 
   await User.findByIdAndUpdate(user.id, { refreshToken });
 
-  res.send({ id: user.id, nickname: user.nickname, token: accessToken });
+  res.send({
+    id: user.id,
+    nickname: user.nickname,
+    imageUrl: user.imageUrl,
+    token: accessToken,
+  });
 };

--- a/controllers/game.js
+++ b/controllers/game.js
@@ -1,5 +1,4 @@
 const { Game, getGamesByUserId } = require('../models/Game');
-const { convertFirstLetterCase } = require('../utils');
 const User = require('../models/User');
 
 exports.getTotalRecord = async (req, res) => {
@@ -36,12 +35,11 @@ exports.getTotalRecord = async (req, res) => {
     const total = { ...acc };
     total.distance += game.distance;
     total.time += game.time;
-    const mode = convertFirstLetterCase(game.mode);
 
     if (game.isWinner) {
-      total[mode].isWinner += 1;
-    } else if (total[mode].isLoser !== undefined) {
-      total[mode].isLoser += 1;
+      total[game.mode].isWinner += 1;
+    } else if (total[game.mode].isLoser !== undefined) {
+      total[game.mode].isLoser += 1;
     }
 
     return total;

--- a/controllers/room.js
+++ b/controllers/room.js
@@ -5,3 +5,16 @@ exports.getRoomList = async (req, res) => {
 
   return res.send(roomList);
 };
+
+exports.createRoom = async (req, res) => {
+  const { mode, title, speed, time } = req.body;
+  const { id } = await Room.create({
+    mode,
+    title,
+    speed,
+    time,
+    participants: [],
+  });
+
+  res.send({ id });
+};

--- a/controllers/tests/auth.test.js
+++ b/controllers/tests/auth.test.js
@@ -65,7 +65,7 @@ describe('Auth Controller', () => {
       });
     });
 
-    it('id, nickname, accessToken으로 응답한다.', async () => {
+    it('id, nickname, imageUrl, accessToken으로 응답한다.', async () => {
       const req = createRequest({
         url: '/auth/signin',
         body: {
@@ -79,6 +79,7 @@ describe('Auth Controller', () => {
 
       expect(res._getData()).toEqual({
         id: 'id',
+        imageUrl: 'imageUrl',
         nickname: 'nickname',
         token: 'accessToken',
       });

--- a/controllers/tests/game.test.js
+++ b/controllers/tests/game.test.js
@@ -71,7 +71,7 @@ describe('Game Controller', () => {
         distance: 1.4,
         time: 30,
         speed: 3.6,
-        Survival: {
+        survival: {
           isWinner: true,
         },
       });

--- a/controllers/tests/room.test.js
+++ b/controllers/tests/room.test.js
@@ -2,7 +2,7 @@ const { createRequest, createResponse } = require('node-mocks-http');
 
 const dummyRooms = require('../../models/sample_room.json');
 const Room = require('../../models/Room');
-const { getRoomList } = require('../room');
+const { getRoomList, createRoom } = require('../room');
 
 jest.mock('../../models/Room');
 
@@ -19,6 +19,29 @@ describe('Room Cotroller', () => {
       await getRoomList(req, res);
 
       expect(res._getData()).toEqual(dummyRooms);
+    });
+  });
+
+  describe('createRoom', () => {
+    it('새로운 room을 생성하고 room id로 응답한다', async () => {
+      const room = {
+        mode: 'mode',
+        title: 'title',
+        speed: 'speed',
+        time: 'time',
+      };
+      const req = createRequest({
+        url: '/room',
+        method: 'POST',
+        body: room,
+      });
+      const res = createResponse();
+      Room.create = jest.fn(async () => ({ id: 'id' }));
+
+      await createRoom(req, res);
+
+      expect(Room.create).toBeCalledWith({ ...room, participants: [] });
+      expect(res._getData()).toEqual({ id: 'id' });
     });
   });
 });

--- a/database/database.js
+++ b/database/database.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+const uniqueValidator = require('mongoose-unique-validator');
+
 const config = require('../config');
 
 exports.connectDB = () => {
@@ -14,4 +16,8 @@ exports.useVirtualId = (schema) => {
   });
   schema.set('toJSON', { virtuals: true });
   schema.set('toObject', { virtuals: true });
+};
+
+exports.validateUnique = (schema) => {
+  schema.plugin(uniqueValidator);
 };

--- a/middlewares/validators.js
+++ b/middlewares/validators.js
@@ -32,14 +32,14 @@ exports.validateRoom = (req, res, next) => {
     throw new Error('mode는 survival, oneOnOne, solo 중에 하나여야 합니다');
   }
 
+  if (!(typeof title === 'string')) {
+    throw new Error('title은 문자열이어야 합니다');
+  }
+
   req.body.title = req.body.title.trim();
 
   if (!req.body.title) {
     throw new Error('title이 없습니다');
-  }
-
-  if (!(typeof title === 'string')) {
-    throw new Error('title은 문자열이어야 합니다');
   }
 
   if (speed && !(typeof speed === 'number')) {

--- a/middlewares/validators.js
+++ b/middlewares/validators.js
@@ -20,3 +20,43 @@ exports.validateQuery = async (req, res, next) => {
 
   return next();
 };
+
+exports.validateRoom = (req, res, next) => {
+  const { mode, title, speed, time } = req.body;
+
+  if (!mode) {
+    throw new Error('mode가 없습니다');
+  }
+
+  if (!['survival', 'oneOnOne', 'solo'].includes(mode)) {
+    throw new Error('mode는 survival, oneOnOne, solo 중에 하나여야 합니다');
+  }
+
+  req.body.title = req.body.title.trim();
+
+  if (!req.body.title) {
+    throw new Error('title이 없습니다');
+  }
+
+  if (!(typeof title === 'string')) {
+    throw new Error('title은 문자열이어야 합니다');
+  }
+
+  if (speed && !(typeof speed === 'number')) {
+    throw new Error('speed는 숫자여야 합니다');
+  }
+
+  if (speed && (speed < 1 || speed > 20)) {
+    throw new Error('speed는 1 이상 20 이하여야 합니다');
+  }
+
+  if (time && !(typeof time === 'number')) {
+    throw new Error('time은 숫자여야 합니다');
+  }
+
+  if (time && !(time < 30 || time > 2000)) {
+    throw new Error('time은 30 이상 2000이하여야 합니다');
+  }
+
+  next();
+};

--- a/middlewares/validators.js
+++ b/middlewares/validators.js
@@ -5,17 +5,17 @@ exports.validateQuery = async (req, res, next) => {
   const { userId } = req.query;
 
   if (!userId) {
-    return res.status(400).send('userId 쿼리를 전달해주어야 합니다.');
+    throw new Error('userId 쿼리를 전달해주어야 합니다.');
   }
 
   if (!mongoose.isValidObjectId(userId)) {
-    return res.status(400).send('유효하지 않은 userId 입니다');
+    throw new Error('유효하지 않은 userId 입니다');
   }
 
   const user = await User.findById(userId);
 
   if (!user) {
-    return res.status(404).send(`해당 유저를 찾을 수 없습니다 id: ${userId}`);
+    throw new Error(`해당 유저를 찾을 수 없습니다 id: ${userId}`);
   }
 
   return next();

--- a/models/Game.js
+++ b/models/Game.js
@@ -24,8 +24,8 @@ const playerSchema = new mongoose.Schema({
   role: {
     type: String,
     required: true,
-    enum: ['Human', 'Zombie'],
-    default: 'Human',
+    enum: ['human', 'zombie'],
+    default: 'human',
   },
 });
 
@@ -34,7 +34,7 @@ const gameSchema = new mongoose.Schema(
     mode: {
       type: String,
       required: true,
-      enum: ['Solo', 'OneOnOne', 'Surviavl'],
+      enum: ['solo', 'oneOnOne', 'surviavl'],
     },
     players: {
       type: [playerSchema],

--- a/models/Room.js
+++ b/models/Room.js
@@ -1,5 +1,7 @@
 const mongoose = require('mongoose');
 
+const { useVirtualId } = require('../database/database');
+
 const roomSchema = mongoose.Schema({
   mode: {
     type: String,
@@ -20,5 +22,7 @@ const roomSchema = mongoose.Schema({
     },
   ],
 });
+
+useVirtualId(roomSchema);
 
 module.exports = mongoose.model('Room', roomSchema);

--- a/models/Room.js
+++ b/models/Room.js
@@ -5,7 +5,7 @@ const { useVirtualId } = require('../database/database');
 const roomSchema = mongoose.Schema({
   mode: {
     type: String,
-    enum: ['OneOnOne', 'Survival'],
+    enum: ['oneOnOne', 'survival'],
     required: true,
   },
   title: {

--- a/models/User.js
+++ b/models/User.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+
 const { useVirtualId } = require('../database/database');
 
 const userSchema = new mongoose.Schema({

--- a/models/User.js
+++ b/models/User.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 
-const { useVirtualId } = require('../database/database');
+const { useVirtualId, validateUnique } = require('../database/database');
 
 const userSchema = new mongoose.Schema({
   email: {
@@ -29,5 +29,6 @@ const userSchema = new mongoose.Schema({
 });
 
 useVirtualId(userSchema);
+validateUnique(userSchema);
 
 module.exports = mongoose.model('User', userSchema);

--- a/models/User.js
+++ b/models/User.js
@@ -21,6 +21,10 @@ const userSchema = new mongoose.Schema({
       ref: 'Game',
     },
   ],
+  refreshToken: {
+    type: String,
+    unique: true,
+  },
 });
 
 useVirtualId(userSchema);

--- a/models/sample_game.json
+++ b/models/sample_game.json
@@ -1,7 +1,7 @@
 [
   {
     "_id": "61fb705f939afdfb71e704bc",
-    "mode": "Solo",
+    "mode": "solo",
     "players": [
       {
         "id": "61fb6ad0939afdfb71e704af",
@@ -9,13 +9,13 @@
         "distance": 1.4,
         "time": 30,
         "speed": 3.6,
-        "role": "Human"
+        "role": "human"
       }
     ]
   },
   {
     "_id": "61fdfc3c7c44bc8b4bc97186",
-    "mode": "Solo",
+    "mode": "solo",
     "players": [
       {
         "id": "61fb6ad0939afdfb71e704af",
@@ -23,13 +23,13 @@
         "distance": 1,
         "time": 30,
         "speed": 3.6,
-        "role": "Human"
+        "role": "human"
       }
     ]
   },
   {
     "_id": "61fb705f939afdfb71e704bd",
-    "mode": "Survival",
+    "mode": "survival",
     "players": [
       {
         "id": "61fb6ad0939afdfb71e704ae",
@@ -37,7 +37,7 @@
         "distance": 1.4,
         "time": 30,
         "speed": 3.6,
-        "role": "Human"
+        "role": "human"
       },
       {
         "id": "61fb6ad0939afdfb71e704af",
@@ -45,7 +45,7 @@
         "distance": 0,
         "time": 0,
         "speed": 0,
-        "role": "Human"
+        "role": "human"
       },
       {
         "id": "61fb6ad0939afdfb71e704b0",
@@ -53,13 +53,13 @@
         "distance": 0,
         "time": 0,
         "speed": 0,
-        "role": "Human"
+        "role": "human"
       }
     ]
   },
   {
     "_id": "61fb705f939afdfb71e704be",
-    "mode": "OneOnOne",
+    "mode": "oneOnOne",
     "players": [
       {
         "id": "61fb6ad0939afdfb71e704af",
@@ -67,7 +67,7 @@
         "distance": 1.4,
         "time": 30,
         "speed": 3.6,
-        "role": "Human"
+        "role": "human"
       },
       {
         "id": "61fb6ad0939afdfb71e704b0",
@@ -75,7 +75,7 @@
         "distance": 0,
         "time": 0,
         "speed": 0,
-        "role": "Zombie"
+        "role": "zombie"
       }
     ]
   }

--- a/models/sample_room.json
+++ b/models/sample_room.json
@@ -1,13 +1,13 @@
 [
   {
-    "mode": "OneOnOne",
+    "mode": "oneOnOne",
     "title": "test room 1",
     "speed": null,
     "time": 30,
     "participants": ["61fb6ad0939afdfb71e704ae", "61fb6ad0939afdfb71e704af"]
   },
   {
-    "mode": "Survival",
+    "mode": "survival",
     "title": "test room 2",
     "speed": 6,
     "time": null,
@@ -18,7 +18,7 @@
     ]
   },
     {
-    "mode": "Survival",
+    "mode": "survival",
     "title": "test room 3",
     "speed": 4,
     "time": null,

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "helmet": "^5.0.2",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.2.0",
+    "mongoose-unique-validator": "^3.0.0",
     "morgan": "^1.10.0"
   },
   "devDependencies": {

--- a/routes/room.js
+++ b/routes/room.js
@@ -1,13 +1,12 @@
 const express = require('express');
 
-const router = express.Router();
-
 const roomController = require('../controllers/room');
 
+const router = express.Router();
+
 router.get('/', roomController.getRoomList);
-router.post('/', (req, res, next) => {});
+router.post('/', roomController.createRoom);
 router.put('/:id/enter', (req, res, next) => {});
-router.put('/:id/exit', (req, res, next) => {});
 router.delete('/:id/exit', (req, res, next) => {});
 
 module.exports = router;

--- a/routes/room.js
+++ b/routes/room.js
@@ -6,7 +6,5 @@ const router = express.Router();
 
 router.get('/', roomController.getRoomList);
 router.post('/', roomController.createRoom);
-router.put('/:id/enter', (req, res, next) => {});
-router.delete('/:id/exit', (req, res, next) => {});
 
 module.exports = router;

--- a/routes/room.js
+++ b/routes/room.js
@@ -1,10 +1,12 @@
 const express = require('express');
+const { body } = require('express-validator');
 
 const roomController = require('../controllers/room');
+const { validateRoom } = require('../middlewares/validators');
 
 const router = express.Router();
 
 router.get('/', roomController.getRoomList);
-router.post('/', roomController.createRoom);
+router.post('/', validateRoom, roomController.createRoom);
 
 module.exports = router;

--- a/utils.js
+++ b/utils.js
@@ -1,9 +1,0 @@
-exports.convertFirstLetterCase = (string) => {
-  const isFirstUpperCase = /[A-Z]/.test(string[0]);
-  const firstLetter = isFirstUpperCase
-    ? string[0].toLowerCase()
-    : string[0].toUpperCase();
-  const leftLetters = string.slice(1);
-
-  return firstLetter + leftLetters;
-};


### PR DESCRIPTION
## 노션 칸반 링크

- [[Backend] 방 생성하기](https://www.notion.so/vanillacoding/Backend-341aae37ebd643ccaaa59f9eea9829f7)

## 구현 사항

- createRoom controller 작성

## 테스트 방법

- 테스트 코드 작성
- Thunder Client로 확인

## 보고 사항

- 게임 모드와 플레이어 롤의 철자가 스키마와 API Docs가 달라 혼선이 발생하여 전부 첫글자 소문자로 통일
- 위 변경사항으로 `convertFirstLetterCase` 유틸함수의 용도가 없어져 삭제함
- signIn 버그 수정
- REST API로 계획되었으나 Socket으로 대체될 API들의 routes 삭제