### PR TITLE
Socket 이벤트 리스너 업데이트

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ const express = require('express');
 const morgan = require('morgan');
 const helmet = require('helmet');
 const cors = require('cors');
-const { Server } = require('socket.io');
 require('express-async-errors');
 
 const authRouter = require('./routes/auth');

--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const cors = require('cors');
 require('express-async-errors');
 
 const authRouter = require('./routes/auth');
-const userRouter = require('./routes/user');
 const gameRouter = require('./routes/game');
 const roomRouter = require('./routes/room');
 const config = require('./config');
@@ -27,7 +26,6 @@ app.use(
 );
 
 app.use('/auth', authRouter);
-app.use('/user', userRouter);
 app.use('/game', gameRouter);
 app.use('/room', roomRouter);
 

--- a/connection/listener.js
+++ b/connection/listener.js
@@ -68,15 +68,19 @@ exports.leaveRoom = async (socket) => {
 
     const currentRoom = await Room.findById(socket.room.id);
 
+    socket.to(socket.room.id).emit('room/leave', socket.user.id);
+    socket.leave(socket.room.id);
+    socket.room = null;
+
+    // 플레이어가 1명일 땐 `DELET /room/:id` 요청을 보내 방이 없으므로 return
+    if (!currentRoom) {
+      return;
+    }
+
     currentRoom.participants = currentRoom.participants.filter(
       (player) => String(player.id) !== socket.user.id
     );
     await currentRoom.save();
-
-    socket.to(socket.room.id).emit('room/leave', socket.user.id);
-    socket.leave(socket.room.id);
-
-    socket.room = null;
 
     console.log(`socket::::: user ${socket.user.id} left room`);
   } catch (error) {

--- a/connection/listener.js
+++ b/connection/listener.js
@@ -1,23 +1,22 @@
 const Room = require('../models/Room');
 const Game = require('../models/Game');
 
-exports.joinRoom = async (socket, roomId, user) => {
-  if (socket.roomId) {
+exports.joinRoom = async (socket, room, user) => {
+  if (socket.room) {
     console.error('이미 join된 room이 있습니다');
     return;
   }
 
   try {
-    const room = await Room.findById(roomId);
-    room.participants.push(user);
-    await room.save();
+    const currentRoom = await Room.findById(room.id);
+    currentRoom.participants.push(user);
+    await currentRoom.save();
 
-    socket.roomId = roomId;
-    socket.userId = user.id;
+    socket.room = room;
+    socket.user = user;
 
-    socket.join(roomId);
-    socket.to(roomId).emit('room/join', user);
-
+    socket.join(room.id);
+    socket.to(room.id).emit('room/join', user);
 
     console.log(`socket::::: user ${user.id} joined room`);
   } catch (error) {
@@ -25,25 +24,39 @@ exports.joinRoom = async (socket, roomId, user) => {
   }
 };
 
-exports.ready = (socket) => {
+exports.ready = async (socket) => {
   try {
     checkIfJoinRoom(socket);
 
-    socket.to(socket.roomId).emit('room/ready', socket.userId);
+    socket.to(socket.room.id).emit('room/ready', socket.user.id);
 
-    console.log(`socket::::: user ${socket.userId} is ready`);
+    const currentRoom = await Room.findById(socket.room.id);
+    const user = currentRoom.participants.find(
+      (player) => String(player.id) === socket.user.id
+    );
+    user.isReady = true;
+    await currentRoom.save();
+
+    console.log(`socket::::: user ${socket.user.id} is ready`);
   } catch (error) {
     console.error(error);
   }
 };
 
-exports.notReady = (socket) => {
+exports.notReady = async (socket) => {
   try {
     checkIfJoinRoom(socket);
 
-    socket.to(socket.roomId).emit('room/notReady', socket.userId);
+    socket.to(socket.room.id).emit('room/notReady', socket.user.id);
 
-    console.log(`socket::::: user ${socket.userId} is not ready`);
+    const currentRoom = await Room.findById(socket.room.id);
+    const user = currentRoom.participants.find(
+      (player) => String(player.id) === socket.user.id
+    );
+    user.isReady = false;
+    await currentRoom.save();
+
+    console.log(`socket::::: user ${socket.user.id} is not ready`);
   } catch (error) {
     console.error(error);
   }
@@ -53,19 +66,19 @@ exports.leaveRoom = async (socket) => {
   try {
     checkIfJoinRoom(socket);
 
-    const room = await Room.findById(socket.roomId);
+    const currentRoom = await Room.findById(socket.room.id);
 
-    room.participants = room.participants.filter(
-      (participant) => String(participant.id) !== socket.userId
+    currentRoom.participants = currentRoom.participants.filter(
+      (player) => String(player.id) !== socket.user.id
     );
-    await room.save();
+    await currentRoom.save();
 
-    socket.roomId = null;
+    socket.to(socket.room.id).emit('room/leave', socket.user.id);
+    socket.leave(socket.room.id);
 
-    socket.to(socket.roomId).emit('room/leave', socket.userId);
-    socket.leave(socket.roomId);
+    socket.room = null;
 
-    console.log(`socket::::: user ${socket.userId} left room`);
+    console.log(`socket::::: user ${socket.user.id} left room`);
   } catch (error) {
     console.error(error);
   }
@@ -75,10 +88,10 @@ exports.die = (socket) => {
   try {
     checkIfJoinRoom(socket);
 
-    socket.to(socket.roomId).emit('game/die', socket.userId);
-    socket.leave(socket.roomId);
+    socket.to(socket.room.id).emit('game/die', socket.user.id);
+    socket.leave(socket.room.id);
 
-    console.log(`socket::::: user ${socket.userId} is dead`);
+    console.log(`socket::::: user ${socket.user.id} is dead`);
   } catch (error) {
     console.error(error);
   }
@@ -94,9 +107,9 @@ exports.startGame = async (socket, mode) => {
     });
     await Room.findByIdAndDelete(socket.roomId);
 
-    socket.to(socket.roomId).emit('game/start', id);
+    socket.to(socket.room.id).emit('game/start', id);
 
-    console.log(`socket::::: game started: ${socket.roomId}`);
+    console.log(`socket::::: game started: ${socket.room.id}`);
   } catch (error) {
     console.error(error);
   }
@@ -115,7 +128,7 @@ exports.sendOpponentSpeed = (socket, speed) => {
 };
 
 function checkIfJoinRoom(socket) {
-  if (!socket.roomId) {
+  if (!socket.room) {
     throw new Error('socket이 room에 join되지 않았습니다');
   }
 }

--- a/connection/socket.js
+++ b/connection/socket.js
@@ -14,8 +14,8 @@ class Socket {
     this.io.on('connect', (socket) => {
       console.log(`socket::::: ${socket.id} connected`);
 
-      socket.on('room/join', (roomId, user) => {
-        listener.joinRoom(socket, roomId, user);
+      socket.on('room/join', (room, user) => {
+        listener.joinRoom(socket, room, user);
       });
       socket.on('room/ready', () => {
         listener.ready(socket);

--- a/controllers/auth.js
+++ b/controllers/auth.js
@@ -15,7 +15,6 @@ exports.signIn = async (req, res, next) => {
       nickname,
       imageUrl,
       gameHistory: [],
-      refreshToken: null,
     });
   }
 

--- a/models/Room.js
+++ b/models/Room.js
@@ -14,6 +14,11 @@ const participantsSchema = new mongoose.Schema({
   imageUrl: {
     type: String,
   },
+  isReady: {
+    type: Boolean,
+    required: true,
+    default: false,
+  },
 });
 
 const roomSchema = mongoose.Schema({

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,5 +1,0 @@
-const express = require('express');
-
-const router = express.Router();
-
-module.exports = router;


### PR DESCRIPTION
## 노션 칸반 링크

- [[FrontEnd] Survival 컴포넌트 작성](https://www.notion.so/vanillacoding/FrontEnd-Survival-41ea08c4e6c84b5e88cb457348a6d625)

## 구현사항

- Socket 이벤트 리스너 업데이트
- Player Schema 업데이트

## 테스트 방법

- 프론트엔드와 연결하여 확인

## 보고 사항

- 현재 `/user` 라우트는 사용하지 않아 삭제하였습니다.
- `joinRoom`의 인자로 room은 Id만 받고 user는 객체로 받는 점이 frontend 작업의 혼란을 가중시켜 모두 객체로 통일시켰습니다.
- 플레이어의 Ready여부를 데이터베이스에 저장합니다.
- 코드 작성 의도가 모호할 수 있는 부분에 주석을 추가하였습니다.
