### PR TITLE
updateGameRecord의 비동기 로직 병렬 방식으로 변경

### DIFF
--- a/controllers/game.js
+++ b/controllers/game.js
@@ -107,11 +107,12 @@ exports.updateGameRecord = async (req, res) => {
   const { id } = req.params;
   const { id: userId, isWinner, distance, time, speed, role } = req.body;
 
-  await Game.findByIdAndUpdate(id, {
-    $push: { players: { id: userId, isWinner, distance, time, speed, role } },
-  });
-
-  await User.findByIdAndUpdate(userId, { $push: { gameHistory: id } });
+  await Promise.all([
+    Game.findByIdAndUpdate.bind(Game, id, {
+      $push: { players: { id: userId, isWinner, distance, time, speed, role } },
+    }),
+    User.findByIdAndUpdate.bind(User, userId, { $push: { gameHistory: id } }),
+  ]);
 
   res.status(201).end();
 };


### PR DESCRIPTION
- 작업 내용
직렬로 배열한 await을 Promise.all로 병렬 배열하여 쿼리 속도를 개선시켰습니다.

- 테스트 방법
안드로이드 에뮬레이터와 안드로이드 기기를 사용하여 테스트